### PR TITLE
feat: add syncx cross-posting skill

### DIFF
--- a/skills/syncx-skill/SKILL.md
+++ b/skills/syncx-skill/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: syncx
+displayName: syncx
+version: 1.0.0
+description: One-stop crypto creator autopost workflow for syncing the same text post to Binance Square and X/Twitter (plus optional Telegram, Threads, and Farcaster via Neynar) in a single command. Use when user asks to "sync post", "cross-post", "一键同步", "同时发推和广场", "发到 TG/Threads/Farcaster", or needs setup/troubleshooting for Binance Square API key, X API credentials, X browser-cookie mode, Telegram bot/channel posting, Farcaster Neynar signer setup, and multi-platform posting automation.
+---
+
+# SyncX｜加密信息一站式同步器
+
+## Overview
+Use this skill as an interaction-first autopost operator for crypto creators.
+Guide user through setup, verification, and publishing with clear branch routing, with Binance Square + X as the default target pair.
+
+## Prerequisites
+All command examples assume you run from `SyncX/skills/syncx`:
+
+```bash
+git clone https://github.com/SyncX2026/SyncX.git
+cd SyncX/skills/syncx
+```
+
+## Core Workflow
+1. Route intent first.
+- `publish-now`: user already has content and wants immediate sync.
+- `setup`: user asks how to configure API/token.
+- `troubleshoot`: user has failure codes or partial success.
+2. Confirm target platforms.
+- Default to `square,twitter` when user says "同步" but does not specify.
+3. Select X mode as a normal branch.
+- Branch A: `official` (X developer credentials path).
+- Branch B: `browser` (session cookie path: `auth_token + ct0`).
+4. Ensure config exists.
+- Run `python3 scripts/publish_sync.py --init-config` if `.env` is missing.
+- Or copy `.env.example` to `.env`.
+5. Fill config safely.
+- Never print full secret values back to user.
+- If user shares keys in chat, persist only to local `.env` and mask in output.
+6. Validate before posting.
+- Run `python3 scripts/publish_sync.py --doctor --platforms <...> --twitter-mode <...>`.
+7. Publish and return structured result.
+- Run `python3 scripts/publish_sync.py --text "..." --platforms <...> --twitter-mode <...>`.
+- Return success/failure per platform with URL/ID when available.
+
+## Interactive Routing Rules
+Apply this branch logic in every conversation:
+
+1. If user says "直接发" and provided text:
+- Run doctor first.
+- If doctor fails, ask only for missing keys and provide the exact reference file.
+- Once doctor passes, execute publish.
+
+2. If user asks "怎么配":
+- Route by platform and mode.
+- For X: ask whether they want `official` or `browser` path.
+- Return copy-ready `.env` keys and exact command sequence.
+
+3. If user says "报错了":
+- Ask for raw JSON output or error code.
+- Route to `references/troubleshooting.md`.
+- Retry with single-platform test, then fan-out test.
+
+4. If environment is missing (`python` not found, command not found):
+- Route to `references/environment.md`.
+- Complete environment checks first, then continue normal flow.
+
+## Command Patterns
+Use these exact command shapes.
+
+### 1) Initialize local config
+```bash
+python3 scripts/publish_sync.py --init-config
+```
+
+### 2) Validate config only
+```bash
+python3 scripts/publish_sync.py \
+  --doctor \
+  --platforms square,twitter \
+  --twitter-mode official
+```
+
+### 3) Publish to Binance Square + X (default MVP)
+```bash
+python3 scripts/publish_sync.py \
+  --text "BTC 回踩后继续上攻，关注 4h 结构" \
+  --platforms square,twitter \
+  --twitter-mode official
+```
+
+### 4) Publish to X browser-session mode + Square
+```bash
+python3 scripts/publish_sync.py \
+  --text "今日策略更新：严格风控" \
+  --platforms square,twitter \
+  --twitter-mode browser
+```
+
+### 5) Publish to Square + X + Telegram
+```bash
+python3 scripts/publish_sync.py \
+  --text "晚间复盘：BTC 关键位 68k" \
+  --platforms square,twitter,tg \
+  --twitter-mode official
+```
+
+### 6) Dry run for safe pre-check
+```bash
+python3 scripts/publish_sync.py \
+  --text "test" \
+  --platforms square,twitter,tg,threads,farcaster \
+  --twitter-mode official \
+  --dry-run
+```
+
+### 7) Publish to Farcaster only
+```bash
+python3 scripts/publish_sync.py \
+  --text "今日复盘：BTC 4h 级别出现结构拐点" \
+  --platforms farcaster
+```
+
+## Farcaster Neynar Setup
+Farcaster 通过 Neynar managed signer 路径接入，必须完成 signer 批准后才能发帖。
+
+Required env keys:
+- `NEYNAR_API_KEY`
+- `FARCASTER_SIGNER_UUID`
+
+Steps:
+1. 在 Neynar 注册并创建 App，获取 `NEYNAR_API_KEY`。
+2. 在 Neynar 发起 signer request。
+3. 用 Warpcast 打开签名链接并批准 signer。
+4. 将 signer UUID 写入 `FARCASTER_SIGNER_UUID`。
+
+Verification:
+```bash
+python3 scripts/publish_sync.py --doctor --platforms farcaster
+```
+
+## Platform Matrix
+- `square`: Binance Square OpenAPI text publishing.
+- `twitter` (`official`): X API v2 `/2/tweets` with OAuth1 user credentials.
+- `twitter` (`browser`): X web-session mode using `auth_token + ct0` cookies.
+- `tg`: Telegram Bot API `sendMessage` to channel/group/chat.
+- `threads`: Optional Graph API two-step publish.
+- `farcaster`: Neynar `cast` API with approved `signer_uuid`.
+
+## Setup References
+Load only the file you need:
+- Quick start: `references/get-started.md`
+- Environment and runtime checks: `references/environment.md`
+- Binance Square setup: `references/setup-square.md`
+- X official API setup: `references/setup-twitter-official.md`
+- X browser mode setup: `references/setup-twitter-browser.md`
+- Telegram setup: `references/setup-telegram.md`
+- Threads setup: `references/setup-threads.md`
+- Farcaster (Neynar) setup: `SKILL.md#farcaster-neynar-setup`
+- Troubleshooting: `references/troubleshooting.md`
+- Q&A script: `references/qa.md`
+- Source links: `references/sources.md`
+
+## Behavior Rules
+1. Prefer execution over explanation.
+- If user gave text and asked to sync, run doctor then post.
+2. Fail partially, report fully.
+- One platform failure must not block others.
+- Return per-platform status with error details.
+3. Keep secrets safe.
+- Never echo full tokens.
+- Use masked format like `abc12...9xyz` in summaries.
+4. Respect content limitations.
+- Binance Square API currently supports text-only posts in this flow.
+5. Ask only when truly blocked.
+- Missing required key/token should trigger a concise request for exactly the missing item.
+6. Keep interactions stepwise.
+- Ask one blocking question at a time.
+- Always provide the next executable command, not generic advice.
+
+## Practical Defaults
+- Default `platforms`: `square,twitter`
+- Default `twitter-mode`: `official`
+- Default config path: `SyncX/skills/syncx/.env`
+- Timeout: `25s`
+
+## Quick Troubleshooting Hooks
+When publish fails, run these in order:
+1. `python3 scripts/publish_sync.py --doctor --platforms <...> --twitter-mode <...>`
+2. `python3 scripts/publish_sync.py --text "ping" --platforms <...> --dry-run`
+3. Re-run publish and inspect platform-specific error in JSON output.
+
+## Local Validation
+Run smoke test before release changes:
+```bash
+python3 scripts/smoke_test.py
+```

--- a/skills/syncx-skill/references/environment.md
+++ b/skills/syncx-skill/references/environment.md
@@ -1,0 +1,71 @@
+# Environment Prerequisites
+
+## Minimum Runtime
+- Python 3.9+ (recommended 3.10+)
+- Local shell access
+- Outbound network access to Binance/X/Telegram/Threads APIs
+
+## Quick Checks
+```bash
+python3 --version
+python3 scripts/publish_sync.py --help
+```
+
+## If `python3` Is Missing
+
+### macOS (Homebrew)
+```bash
+brew install python
+python3 --version
+```
+
+### Ubuntu / Debian
+```bash
+sudo apt update
+sudo apt install -y python3
+python3 --version
+```
+
+### CentOS / RHEL
+```bash
+sudo yum install -y python3
+python3 --version
+```
+
+## If `python` Exists But `python3` Does Not
+Use your available interpreter explicitly:
+```bash
+python scripts/publish_sync.py --help
+```
+
+## If Shell Reports "command not found"
+1. Confirm current directory:
+```bash
+pwd
+ls -la
+```
+2. Switch to skill directory:
+```bash
+cd SyncX/skills/syncx
+```
+3. Run with explicit path:
+```bash
+python3 scripts/publish_sync.py --help
+```
+
+## Network/Firewall Checklist
+If requests fail with network errors:
+1. Verify DNS and outbound HTTPS.
+2. Test target domains from host:
+- `www.binance.com`
+- `api.x.com`
+- `api.telegram.org`
+- `graph.threads.net`
+3. Retry using single-platform publish first.
+
+## First-Run Sequence
+```bash
+python3 scripts/publish_sync.py --init-config
+python3 scripts/publish_sync.py --doctor --platforms square,twitter --twitter-mode official
+python3 scripts/publish_sync.py --text "test" --platforms square,twitter --twitter-mode official
+```

--- a/skills/syncx-skill/references/get-started.md
+++ b/skills/syncx-skill/references/get-started.md
@@ -1,0 +1,52 @@
+# Quick Start (10 Minutes)
+
+## 0) Verify environment
+```bash
+python3 --version
+python3 scripts/publish_sync.py --help
+```
+If this fails, follow `references/environment.md`.
+
+## 1) Generate local config template
+```bash
+python3 scripts/publish_sync.py --init-config
+```
+
+## 2) Fill minimum fields for MVP (Square + X)
+Edit `.env`:
+```env
+BINANCE_SQUARE_API_KEY=...
+TWITTER_API_KEY=...
+TWITTER_API_SECRET=...
+TWITTER_ACCESS_TOKEN=...
+TWITTER_ACCESS_SECRET=...
+```
+
+## 3) Validate credentials
+```bash
+python3 scripts/publish_sync.py \
+  --doctor \
+  --platforms square,twitter \
+  --twitter-mode official
+```
+
+## 4) Post once
+```bash
+python3 scripts/publish_sync.py \
+  --text "BTC 日内关注 68k 支撑，严格止损" \
+  --platforms square,twitter \
+  --twitter-mode official
+```
+
+## 5) Expand to Telegram
+Append to `.env`:
+```env
+TELEGRAM_BOT_TOKEN=...
+TELEGRAM_CHAT_ID=...
+```
+Then publish:
+```bash
+python3 scripts/publish_sync.py \
+  --text "复盘更新" \
+  --platforms square,twitter,tg
+```

--- a/skills/syncx-skill/references/qa.md
+++ b/skills/syncx-skill/references/qa.md
@@ -1,0 +1,62 @@
+# Q&A (Self-Contained)
+
+## Q1: Where do I get Binance Square API key?
+From Binance Creator Center -> API section -> create/view Square posting API key. Put into `BINANCE_SQUARE_API_KEY`.
+
+## Q2: Why can Square post fail even with valid key?
+Common reasons: empty text (`220011`), risky text (`20022`), daily quota exceeded (`220009`), expired key (`220004`).
+
+## Q3: How do I configure X official API mode?
+Prepare 4 values in `.env`:
+- `TWITTER_API_KEY`
+- `TWITTER_API_SECRET`
+- `TWITTER_ACCESS_TOKEN`
+- `TWITTER_ACCESS_SECRET`
+Then run doctor with `--twitter-mode official`.
+
+## Q4: How do I configure X browser mode (token/cookie mode)?
+Get `auth_token` and `ct0` cookies from logged-in browser session and set:
+- `TWITTER_AUTH_TOKEN`
+- `TWITTER_CT0`
+Then publish with `--twitter-mode browser`.
+
+## Q5: Official mode vs browser mode, which is better?
+Official mode is more stable and recommended. Browser mode is an alternate branch for session-cookie based workflows.
+
+## Q6: How do I send to Telegram channel automatically?
+Create bot via `@BotFather`, add bot as channel admin, set:
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_CHAT_ID`
+Use platform list including `tg`.
+
+## Q7: Can I do one-click sync to Square + X together?
+Yes:
+```bash
+python3 scripts/publish_sync.py \
+  --text "你的文案" \
+  --platforms square,twitter \
+  --twitter-mode official
+```
+
+## Q8: Can this also include TG/Threads?
+Yes. Add `tg` and/or `threads` to `--platforms` once credentials are configured.
+
+## Q9: Can image/video be synced too?
+Current Square open API flow in this skill is text-first. X/TG media can be extended later, but this package focuses on stable text sync MVP.
+
+## Q10: How do I verify setup without posting real content?
+Use dry-run:
+```bash
+python3 scripts/publish_sync.py --text "test" --platforms square,twitter --dry-run
+```
+And config doctor:
+```bash
+python3 scripts/publish_sync.py --doctor --platforms square,twitter
+```
+
+## Q11: What if `python3` command is missing?
+Follow `references/environment.md` and install Python first, then rerun quick checks:
+```bash
+python3 --version
+python3 scripts/publish_sync.py --help
+```

--- a/skills/syncx-skill/references/setup-square.md
+++ b/skills/syncx-skill/references/setup-square.md
@@ -1,0 +1,46 @@
+# Binance Square Setup
+
+## Goal
+Enable OpenClaw/AI to publish text posts to Binance Square using `BINANCE_SQUARE_API_KEY`.
+
+## Steps
+1. Open Binance App or Web and go to Creator Center (`创作者中心`).
+2. Enter the API section and create/refresh your Square publishing API key.
+3. Copy the key and store it in `.env`:
+```env
+BINANCE_SQUARE_API_KEY=your_real_key
+```
+4. Verify with doctor:
+```bash
+python3 scripts/publish_sync.py --doctor --platforms square
+```
+
+## Source References
+- Binance official Square skill reference:
+  - `https://github.com/binance/binance-skills-hub/tree/main/skills/binance/square-post`
+- Endpoint definition in cloned reference:
+  - `references/binance-skills-hub/skills/binance/square-post/SKILL.md`
+
+## Publish Endpoint (used by script)
+- `POST https://www.binance.com/bapi/composite/v1/public/pgc/openApi/content/add`
+- Header `X-Square-OpenAPI-Key: <key>`
+- Body field `bodyTextOnly`
+
+## Known Limits
+- Current skill flow is text-only for Square.
+- Each API key has a daily success quota (commonly 100/day by default).
+
+## Common Square Error Codes
+- `000000`: success
+- `220003`: API key not found
+- `220004`: API key expired
+- `220009`: daily OpenAPI quota exceeded
+- `220010`: unsupported content type
+- `220011`: content is empty
+- `20013`: content too long
+- `20022`: sensitive/risky content detected
+
+## Security
+- Do not share key screenshots.
+- Rotate key immediately if leaked.
+- Keep a dedicated posting key with minimal scope.

--- a/skills/syncx-skill/references/setup-telegram.md
+++ b/skills/syncx-skill/references/setup-telegram.md
@@ -1,0 +1,44 @@
+# Telegram Setup (Bot -> Channel/Group)
+
+## Goal
+Allow the same post to be pushed to Telegram via Bot API (`--platforms ... ,tg`).
+
+## Required Values
+```env
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+# Optional:
+TELEGRAM_PARSE_MODE=
+TELEGRAM_CHANNEL_USERNAME=
+```
+
+## Step-by-Step
+1. Open `@BotFather` and create a bot (`/newbot`), copy token.
+2. Add the bot into target group/channel.
+3. Grant admin posting permission if target is a channel.
+4. Determine `chat_id`.
+
+## Getting `chat_id`
+- Private chat with bot: send any message to bot, then inspect `getUpdates`.
+- Group/channel: add bot, send one message, inspect `getUpdates` result.
+- Channel IDs are often negative numeric values (for example `-100...`).
+
+## Verify
+```bash
+python3 scripts/publish_sync.py --doctor --platforms tg
+```
+
+## Publish Test
+```bash
+python3 scripts/publish_sync.py \
+  --text "CT sync test to telegram" \
+  --platforms tg
+```
+
+## Channel URL Notes
+- If channel has public username, set `TELEGRAM_CHANNEL_USERNAME` (without `@`) to get clickable URL output.
+- Without public username, message can still send successfully but URL may be unavailable.
+
+## Source References
+- Telegram Bot API: `https://core.telegram.org/bots/api`
+- sendMessage: `https://core.telegram.org/bots/api#sendmessage`

--- a/skills/syncx-skill/references/setup-threads.md
+++ b/skills/syncx-skill/references/setup-threads.md
@@ -1,0 +1,38 @@
+# Threads Setup (Optional)
+
+## Goal
+Enable optional cross-post to Threads (`--platforms ...,threads`).
+
+## Required Values
+```env
+THREADS_ACCESS_TOKEN=
+THREADS_USER_ID=
+# Optional for pretty URL:
+THREADS_USERNAME=
+```
+
+## API Flow Used
+1. Create media container:
+- `POST /{user-id}/threads` with `media_type=TEXT`, `text`, `access_token`
+2. Publish container:
+- `POST /{user-id}/threads_publish` with `creation_id`, `access_token`
+
+## Verify
+```bash
+python3 scripts/publish_sync.py --doctor --platforms threads
+```
+
+## Publish Test
+```bash
+python3 scripts/publish_sync.py \
+  --text "CT sync test to threads" \
+  --platforms threads
+```
+
+## Notes
+- This integration is optional; main MVP remains Square + X.
+- Threads app review and token lifecycle can affect availability.
+
+## Source References
+- Threads docs: `https://developers.facebook.com/docs/threads`
+- SDK reference used during implementation: `https://github.com/solojungle/threads-ts`

--- a/skills/syncx-skill/references/setup-twitter-browser.md
+++ b/skills/syncx-skill/references/setup-twitter-browser.md
@@ -1,0 +1,50 @@
+# X / Twitter Browser Session Mode
+
+## When to Use
+Use this when user chooses session-cookie branch (`--twitter-mode browser`) for their workflow.
+
+## Required Values
+```env
+TWITTER_AUTH_TOKEN=
+TWITTER_CT0=
+# Optional, script has built-in default value:
+TWITTER_WEB_BEARER_TOKEN=
+```
+
+## How to Collect
+1. Log in to X in a browser profile.
+2. Open DevTools -> Application/Storage -> Cookies for `x.com`.
+3. Copy values for:
+- `auth_token`
+- `ct0`
+4. Save to `.env` as `TWITTER_AUTH_TOKEN` and `TWITTER_CT0`.
+
+## Verify
+```bash
+python3 scripts/publish_sync.py \
+  --doctor \
+  --platforms twitter \
+  --twitter-mode browser
+```
+
+## Publish Test
+```bash
+python3 scripts/publish_sync.py \
+  --text "CT sync test from browser mode" \
+  --platforms twitter \
+  --twitter-mode browser
+```
+
+## Important Risks
+- Cookie tokens expire or are revoked frequently.
+- 2FA/account checks can break automation unexpectedly.
+- Anti-abuse systems may block requests.
+- This mode is less stable than official API mode.
+
+## Source References
+- Browser-session style reference implementation: `https://github.com/d60/twikit`
+
+## Recovery
+1. Re-export fresh `auth_token` and `ct0`.
+2. Ensure the same account remains logged in.
+3. Retry with short test text before production posts.

--- a/skills/syncx-skill/references/setup-twitter-official.md
+++ b/skills/syncx-skill/references/setup-twitter-official.md
@@ -1,0 +1,55 @@
+# X / Twitter Official API Setup
+
+## Goal
+Enable reliable tweet publishing through official API mode (`--twitter-mode official`).
+
+## Required Credentials
+Put all four values in `.env`:
+```env
+TWITTER_API_KEY=
+TWITTER_API_SECRET=
+TWITTER_ACCESS_TOKEN=
+TWITTER_ACCESS_SECRET=
+```
+
+## How to Get Them
+1. Open X Developer Portal and create/select a project + app.
+2. Ensure your app has post/write capability for user-context posting.
+3. Generate credentials for the posting account:
+- API Key -> `TWITTER_API_KEY`
+- API Secret -> `TWITTER_API_SECRET`
+- Access Token -> `TWITTER_ACCESS_TOKEN`
+- Access Token Secret -> `TWITTER_ACCESS_SECRET`
+4. If app permissions are changed later, regenerate access token/secret.
+5. Save all four values to `.env`.
+
+## Verify
+```bash
+python3 scripts/publish_sync.py \
+  --doctor \
+  --platforms twitter \
+  --twitter-mode official
+```
+
+## Publish Test
+```bash
+python3 scripts/publish_sync.py \
+  --text "CT sync test from official API" \
+  --platforms twitter \
+  --twitter-mode official
+```
+
+## Endpoint (used by script)
+- `POST https://api.x.com/2/tweets`
+- OAuth1 user-context signature in `Authorization` header
+- JSON body: `{"text": "..."}`
+
+## Source Docs
+- X posts creation docs: `https://docs.x.com/x-api/posts/creation-of-a-post`
+- X developer portal: `https://developer.x.com/`
+
+## Failure Checklist
+1. Check whether app has write permission.
+2. Regenerate access token/secret after permission changes.
+3. Confirm account is not restricted/suspended.
+4. Re-run doctor and verify no missing fields.

--- a/skills/syncx-skill/references/sources.md
+++ b/skills/syncx-skill/references/sources.md
@@ -1,0 +1,41 @@
+# Sources
+
+Updated: 2026-03-07
+
+## Binance
+- Binance Skills Hub `square-post` skill:
+  - `references/binance-skills-hub/skills/binance/square-post/SKILL.md`
+  - https://github.com/binance/binance-skills-hub/tree/main/skills/binance/square-post
+
+## X / Twitter
+- Official X API post endpoint docs:
+  - https://docs.x.com/x-api/posts/creation-of-a-post
+- Developer portal:
+  - https://developer.x.com/
+- OAuth 1.0a user-context reference:
+  - https://developer.x.com/en/docs/authentication/oauth-1-0a
+
+## Telegram
+- Official Bot API reference:
+  - https://core.telegram.org/bots/api
+- `sendMessage` details:
+  - https://core.telegram.org/bots/api#sendmessage
+
+## Threads
+- Official Threads docs index:
+  - https://developers.facebook.com/docs/threads
+- Threads API reference collection:
+  - https://www.postman.com/meta/threads/documentation/23987686-ac4d3cf2-4505-40c6-b4f5-45c716dbcc61
+
+## Farcaster
+- Neynar publish cast endpoint:
+  - https://docs.neynar.com/reference/publish-cast
+- Neynar managed signer flow:
+  - https://docs.neynar.com/docs/write-to-farcaster-with-neynar-managed-signers
+
+## Libraries Referenced
+- Twitter SDK: https://github.com/PLhery/node-twitter-api-v2
+- Twitter browser-session style: https://github.com/d60/twikit
+- Telegram SDK: https://github.com/grammyjs/grammY
+- Telegram Python SDK: https://github.com/python-telegram-bot/python-telegram-bot
+- Threads SDK: https://github.com/solojungle/threads-ts

--- a/skills/syncx-skill/references/troubleshooting.md
+++ b/skills/syncx-skill/references/troubleshooting.md
@@ -1,0 +1,77 @@
+# Troubleshooting Playbook
+
+## Fast Triage (always run this first)
+1. Config check:
+```bash
+python3 scripts/publish_sync.py --doctor --platforms square,twitter,tg --twitter-mode official
+```
+2. Dry-run check:
+```bash
+python3 scripts/publish_sync.py --text "ping" --platforms square,twitter,tg --dry-run
+```
+3. Real publish and inspect per-platform JSON errors.
+
+## Binance Square Issues
+
+### `220011` / content empty
+- Cause: empty `bodyTextOnly`.
+- Fix: pass `--text` or `--text-file` with non-empty content.
+
+### `220003` / key not found
+- Cause: wrong API key.
+- Fix: regenerate key from Creator Center and update `BINANCE_SQUARE_API_KEY`.
+
+### `220004` / key expired
+- Fix: rotate and replace key.
+
+### `220009` / daily limit exceeded
+- Fix: wait quota reset; avoid repeated retries.
+
+### `20022` / risky content
+- Fix: remove risky words/URLs and retry.
+
+## X Official API Issues
+
+### Missing credential keys
+- Run doctor and fill all 4 fields:
+- `TWITTER_API_KEY`, `TWITTER_API_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_SECRET`
+
+### 401 / 403-like API failure
+- Check app write permission.
+- Regenerate access token after permission update.
+- Ensure posting account is healthy and not restricted.
+
+## X Browser Mode Issues
+
+### Cookie mode always fails
+- Re-export `auth_token` and `ct0` from fresh logged-in session.
+- Keep same browser account login alive.
+- Confirm `--twitter-mode browser` is used.
+
+### Works once then fails later
+- Tokens expired or invalidated by security checks.
+- Re-capture cookies and retry.
+
+## Telegram Issues
+
+### Bot cannot post to channel
+- Bot not admin or no posting rights.
+- Add bot as admin and enable post permission.
+
+### Wrong chat ID
+- Re-fetch from Bot API `getUpdates` after sending a fresh message.
+
+### No URL returned
+- Channel may not have public username.
+- Set `TELEGRAM_CHANNEL_USERNAME` if available.
+
+## Threads Issues
+
+### Publish step fails after create succeeds
+- Token lacks publish scope or token expired.
+- Re-authorize app and refresh access token.
+
+## Debugging Tips
+- Keep first test text short and plain.
+- Test one platform at a time before full fan-out.
+- Use JSON output as source of truth; do not assume partial success.


### PR DESCRIPTION
## Summary
  This PR adds a new skill: `syncx-skill` for cross-posting
  workflows (Binance Square + X/Twitter, with optional Telegram/
  Threads/Farcaster guidance).

  ## Changes
  - add `skills/syncx-skill/SKILL.md`
  - add `skills/syncx-skill/references/get-started.md`
  - add `skills/syncx-skill/references/environment.md`
  - add `skills/syncx-skill/references/setup-square.md`
  - add `skills/syncx-skill/references/setup-twitter-official.md`
  - add `skills/syncx-skill/references/setup-twitter-browser.md`
  - add `skills/syncx-skill/references/troubleshooting.md`
  - add `skills/syncx-skill/references/qa.md`
  - add `skills/syncx-skill/references/sources.md`

  ## Scope
  - documentation/skill content only
  - no dependency, CI, or runtime code changes

  ## Notes
  - frontmatter follows existing repository style (`name`,
  `displayName`, `version`, `description`)
  - examples are designed for practical creator workflows and safe
  step-by-step setup