### PR TITLE
Feat/skillshub market pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Skills are structured knowledge files that give AI coding agents domain-specific
 | Skill | Description |
 |-------|-------------|
 | **bnbchain-mcp-skill** | Install and use BNB Chain MCP — blocks, transactions, contracts, tokens, NFTs, wallet, ERC-8004 agents, Greenfield. Covers connection, credentials, and every MCP tool. |
+| **bsc-honeypot-check** | Pre-trade risk check for sell restrictions, tax anomalies, and liquidity signals. |
+| **bsc-rpc-fanout-check** | Multi-endpoint RPC health and consistency checks for BSC reads. |
+| **crowding-risk-scan** | Crowd positioning signal for potential squeeze/reversal risk. |
+| **funding-basis-carry-scan** | Funding and basis spread scan for carry setup monitoring. |
+| **funding-watch** | Funding-rate and basis monitor for derivatives risk context. |
+| **kline-brief** | Quick kline summary workflow for short-form market context. |
+| **liquidation-heatmap** | Liquidation cluster awareness for volatility zones. |
+| **open-interest-scan** | Open-interest and flow shift scan for momentum/risk checks. |
+| **price-snapshot** | Fast spot price and 24h delta snapshot. |
+| **symbol-status** | Symbol trading status check (active/limited states). |
+| **top-movers** | Top symbol movers ranking by change/volume filters. |
 
 ## Installation
 
@@ -79,13 +90,17 @@ Example prompts:
 ```
 bnbchain-skills/
 ├── skills/
-│   └── bnbchain-mcp-skill/
+│   ├── bnbchain-mcp-skill/
 │       ├── SKILL.md                    # Main skill: install + tool usage
 │       └── references/
 │           ├── evm-tools-reference.md     # Blocks, transactions, contracts, tokens, NFT, wallet, network
 │           ├── erc8004-tools-reference.md  # ERC-8004 agent tools
 │           ├── greenfield-tools-reference.md # Greenfield storage & payment tools
 │           └── prompts-reference.md         # MCP prompts
+│   ├── bsc-honeypot-check/
+│   │   └── SKILL.md                    # Pre-trade token risk checks
+│   └── top-movers/
+│       └── SKILL.md                    # Market mover ranking workflow
 ├── LICENSE
 └── README.md
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Skills are structured knowledge files that give AI coding agents domain-specific
 | **price-snapshot** | Fast spot price and 24h delta snapshot. |
 | **symbol-status** | Symbol trading status check (active/limited states). |
 | **top-movers** | Top symbol movers ranking by change/volume filters. |
+| **four-meme-agentic-ops** | Agentic decision workflow for Four.meme launch and operation steps. |
+| **four-meme-create-pipeline** | Two-step Four.meme token creation pipeline with confirmation gates. |
+| **four-meme-graduation-radar** | Graduation-stage monitoring workflow for Four.meme projects. |
+| **four-meme-mempool-sentinel** | Read-first mempool watch workflow for Four.meme early signals. |
+| **four-meme-one-stop-bsc** | End-to-end Four.meme on BSC operation playbook. |
+| **four-meme-tax-token-guard** | Tax-token mode risk-check and operation guardrails for Four.meme. |
+| **four-meme-trade-playbook** | Structured Four.meme trade preparation and execution checklist. |
 
 ## Installation
 

--- a/skills/bsc-honeypot-check/SKILL.md
+++ b/skills/bsc-honeypot-check/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: bsc_honeypot_check
+description: Checks sell restrictions, tax anomalies, and multi-DEX liquidity signals before buy-in.
+---
+
+# BSC Honeypot Check
+
+## Usage
+
+- Category: Security
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "tokenAddress": "0x...",
+  "maxPairs": 5
+}
+```
+
+## Local Install (planned)
+
+```bash
+npx @skillshub/bsc-honeypot-check
+```
+
+## Notes
+
+- Combines free API signals from DexScreener and Honeypot simulation.
+- Produces pre-trade risk assessment only; no automatic trade execution.
+- Liquidity lock state from free endpoints can be partial; treat as advisory.

--- a/skills/bsc-rpc-fanout-check/SKILL.md
+++ b/skills/bsc-rpc-fanout-check/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: bsc_rpc_fanout_check
+description: Validates BSC RPC endpoints for health, latency, and block drift.
+---
+
+# BSC RPC Fanout Check
+
+## Usage
+
+- Category: Infrastructure
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "method": "eth_blockNumber",
+  "sampleSize": 2,
+  "blockDriftThreshold": 2,
+  "endpoints": [
+    "https://bsc-dataseed.binance.org",
+    "https://bsc-dataseed1.defibit.io"
+  ]
+}
+```
+
+## Local Install (planned)
+
+```bash
+npx @skillshub/bsc-rpc-fanout-check
+```

--- a/skills/crowding-risk-scan/SKILL.md
+++ b/skills/crowding-risk-scan/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: crowding_risk_scan
+description: Tracks long/short crowding from account ratios, taker flow, and OI change for squeeze warnings.
+---
+
+# Crowding Risk Scan
+
+## Usage
+
+- Category: Derivatives
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "symbol": "BTCUSDT",
+  "period": "1h",
+  "limit": 12
+}
+```
+
+## Local Install (planned)
+
+```bash
+npx @skillshub/crowding-risk-scan
+```
+
+## Notes
+
+- Flags crowding/squeeze risk from multiple futures sentiment datasets.
+- Intended for pre-trade risk filtering, not automated trade execution.

--- a/skills/four-meme-agentic-ops/SKILL.md
+++ b/skills/four-meme-agentic-ops/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: four_meme_agentic_ops
+description: Runs a human-in-the-loop agentic operating loop for Four.meme (discover, score, confirm, execute, monitor, and journal). Use when users ask for automated strategy support without granting fully autonomous hot-wallet trading.
+---
+
+# Four.Meme Agentic Ops
+
+## Usage
+
+- Category: Ecosystem
+- Mode: guide
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "goal": "momentum_entry",
+  "riskTier": "medium",
+  "maxCapitalBnb": 0.6,
+  "entrySlices": 3,
+  "confirmationMode": "human_in_the_loop"
+}
+```
+
+## Operating Loop
+
+1. Discover candidates (read-only):
+   ```bash
+   npx fourmeme token-list
+   npx fourmeme token-rankings
+   ```
+2. Score each candidate with a fixed rubric:
+   - liquidity quality
+   - price acceleration
+   - holder concentration
+   - tax and transfer constraints
+3. Build a proposed execution plan (size, slices, and invalidation).
+4. Ask for explicit confirmation on every write action.
+5. Execute using trade commands from the approved plan:
+   ```bash
+   npx fourmeme quote-buy ...
+   npx fourmeme buy ...
+   npx fourmeme quote-sell ...
+   npx fourmeme sell ...
+   ```
+6. Monitor and journal:
+   ```bash
+   npx fourmeme events <fromBlock> [toBlock]
+   ```
+   Record rationale, execution hash, and post-trade outcome.
+
+## Agentic Policy
+
+- Keep default mode as assistive, not autonomous.
+- Require explicit user confirmation for all on-chain writes.
+- Apply hard risk caps before each order (`maxCapitalBnb`, `maxLossBnb`, `maxSlippageBps`).
+- Re-check wallet and quote right before execution to avoid stale state.
+
+## Source Anchors
+
+- four-meme-ai package + command list: https://www.npmjs.com/package/four-meme-ai
+- Four.meme protocol integration page: https://four-meme.gitbook.io/four.meme/brand/protocol-integration

--- a/skills/four-meme-create-pipeline/SKILL.md
+++ b/skills/four-meme-create-pipeline/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: four_meme_create_pipeline
+description: Plans and executes Four.meme two-step token creation (create-api then create-chain) with confirmation gates, fee sanity checks, and post-create verification. Use when users ask to launch or issue a new token on Four.meme from an agent workflow.
+---
+
+# Four.Meme Create Pipeline
+
+## Usage
+
+- Category: Ecosystem
+- Mode: guide
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "action": "create_token",
+  "network": "bsc",
+  "name": "Meme Agent Coin",
+  "symbol": "MAC",
+  "description": "Agent launch token for BSC growth",
+  "logoPath": "./assets/mac.png",
+  "label": "Meme",
+  "budgetBnb": 0.01,
+  "dryRun": true
+}
+```
+
+## Workflow
+
+1. Run read-only health checks first:
+   ```bash
+   npx fourmeme verify
+   ```
+2. Collect creation payload and render a command preview before any write transaction:
+   ```bash
+   npx fourmeme create-api <args...>
+   ```
+3. Ask for explicit final confirmation (`CONFIRM_CREATE`) with symbol, expected spend, and wallet address.
+4. Execute on-chain creation only after confirmation:
+   ```bash
+   npx fourmeme create-chain <args...>
+   ```
+5. Reconcile output with info/events:
+   ```bash
+   npx fourmeme token-info <tokenAddress>
+   npx fourmeme events <fromBlock> [toBlock]
+   ```
+
+## Guardrails
+
+- Never execute `create-chain` without explicit user confirmation.
+- Default to `dryRun=true` when user intent is ambiguous.
+- Refuse to process plain-text private keys in chat or logs.
+- Abort if chain is not BSC or if verification fails.
+
+## Source Anchors
+
+- four-meme-ai package + CLI references: https://www.npmjs.com/package/four-meme-ai
+- Four.meme protocol integration page: https://four-meme.gitbook.io/four.meme/brand/protocol-integration

--- a/skills/four-meme-graduation-radar/SKILL.md
+++ b/skills/four-meme-graduation-radar/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: four_meme_graduation_radar
+description: Tracks graduation and migration signals from Four.meme bonding curves to Pancake liquidity using rankings, listing flags, and LiquidityAdded events.
+---
+
+# Four.Meme Graduation Radar
+
+## Usage
+
+- Category: Ecosystem
+- Mode: guide
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "action": "scan_graduation",
+  "orderBy": "Graduated",
+  "lookbackBlocks": 1200,
+  "maxCandidates": 20,
+  "minLiquidityUsd": 20000
+}
+```
+
+## Workflow
+
+1. Pull graduation candidates first:
+   ```bash
+   npx fourmeme token-rankings Graduated --barType=HOUR24
+   npx fourmeme token-list --listedPancake=true --pageIndex=1 --pageSize=30
+   ```
+2. Confirm current token state:
+   ```bash
+   npx fourmeme token-info <tokenAddress>
+   npx fourmeme token-get <tokenAddress>
+   ```
+3. Reconcile migration by events in a fixed window:
+   ```bash
+   npx fourmeme events <fromBlock> [toBlock]
+   ```
+   Focus on `LiquidityAdded` + first post-migration swap activity.
+4. Optional enrichment via Bitquery Four Meme API:
+   - top token creators by liquidity added.
+   - top migrated tokens by traded volume.
+5. Output a ranked watchlist:
+   - migration confidence.
+   - liquidity durability.
+   - concentration risk and fade risk.
+
+## Guardrails
+
+- Default to read-only analysis.
+- Do not place buy/sell orders inside this skill flow.
+- Mark mempool-only observations as unconfirmed until on-chain events are finalized.
+- If token metadata or manager version checks fail, downgrade confidence and stop execution advice.
+
+## Source Anchors
+
+- Four.meme CLI command surface: https://github.com/four-meme-community/four-meme-ai
+- Four Meme liquidity/migration query references: https://docs.bitquery.io/docs/blockchain/BSC/four-meme-api/
+- Four.meme protocol integration updates: https://four-meme.gitbook.io/four.meme/brand/protocol-integration

--- a/skills/four-meme-mempool-sentinel/SKILL.md
+++ b/skills/four-meme-mempool-sentinel/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: four_meme_mempool_sentinel
+description: Builds real-time pending-transaction watchlists for Four.meme and upgrades alerts only after event-level confirmation, reducing false positives.
+---
+
+# Four.Meme Mempool Sentinel
+
+## Usage
+
+- Category: Ecosystem
+- Mode: guide
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "action": "watch_pending_flows",
+  "windowSeconds": 45,
+  "minBuyBnb": 0.3,
+  "trackWallets": ["0x..."],
+  "alertLevels": ["watch", "hot", "critical"]
+}
+```
+
+## Workflow
+
+1. Define watch universe:
+   - active Four.meme contracts.
+   - tracked wallets (smart money / known launch wallets).
+   - thresholds by BNB size and tx burst frequency.
+2. Subscribe pending transactions (mempool) and decode candidates:
+   - buy bursts.
+   - repeated wallet fan-out.
+   - suspicious pre-liquidity traffic.
+3. Score pending signals quickly:
+   - size score.
+   - wallet quality score.
+   - crowding score.
+4. Confirm with chain events before escalation:
+   ```bash
+   npx fourmeme events <fromBlock> [toBlock]
+   npx fourmeme token-info <tokenAddress>
+   ```
+5. Emit dual-state alerts:
+   - `pending_signal` (unconfirmed).
+   - `confirmed_signal` (post-event verified).
+
+## Guardrails
+
+- Keep this skill read-only and monitoring-first.
+- Never auto-trade from pending transactions alone.
+- Expire stale pending alerts after the configured window.
+- If data-provider latency is high, downgrade alert confidence.
+
+## Source Anchors
+
+- Bitquery Four Meme API (mempool + migration analytics): https://docs.bitquery.io/docs/blockchain/BSC/four-meme-api/
+- Community MCP integration reference: https://github.com/sunneeee/fourtrader-mcp
+- Four.meme CLI events verification: https://github.com/four-meme-community/four-meme-ai

--- a/skills/four-meme-one-stop-bsc/SKILL.md
+++ b/skills/four-meme-one-stop-bsc/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: four_meme_one_stop_bsc
+description: Runs a one-stop Four.meme workflow that combines token launch, buy execution, tweet material generation, ERC8004 identity setup, and fast operator authorization with revoke discipline. Use when users ask for an end-to-end Four.meme execution playbook instead of separate skills.
+---
+
+# Four.Meme One-Stop Launch
+
+## Usage
+
+- Category: Ecosystem
+- Mode: guide
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "goal": "one_stop_flow",
+  "create": {
+    "name": "Meme Agent Coin",
+    "symbol": "MAC",
+    "budgetBnb": 0.01
+  },
+  "trade": {
+    "side": "buy",
+    "amountBnb": 0.2,
+    "maxSlippageBps": 150
+  },
+  "auth": {
+    "operator": "0x...",
+    "scope": "session",
+    "ttlMinutes": 30
+  }
+}
+```
+
+## One-Stop Sequence
+
+1. Run baseline verification:
+   ```bash
+   npx fourmeme verify
+   ```
+2. Create token in two steps with confirmation:
+   ```bash
+   npx fourmeme create-api <args...>
+   npx fourmeme create-chain <args...>
+   ```
+3. Generate quote and execute trade with confirmation:
+   ```bash
+   npx fourmeme token-info <tokenAddress>
+   npx fourmeme quote-buy <tokenAddress> <amountOrFunds>
+   npx fourmeme buy <tokenAddress> <amountOrFunds> ...
+   ```
+4. Ensure ERC8004 identity readiness:
+   ```bash
+   npx fourmeme 8004-register <name> [imageUrl] [description]
+   npx fourmeme 8004-balance <ownerAddress>
+   ```
+5. Apply short-lived operator authorization, then revoke:
+   - grant: `approve` or `setApprovalForAll(..., true)`
+   - verify: `getApproved` or `isApprovedForAll`
+   - revoke: `approve(address(0), agentId)` or `setApprovalForAll(..., false)`
+6. Generate tweet materials package (single tweet + thread + CTA):
+   - Summary tweet: project hook + token symbol + launch context + risk note.
+   - Thread draft (3-5 posts): why now, what utility, how to participate.
+   - CTA variants: buy-in prompt, community invite, and risk disclaimer.
+   - Optional style pass:
+     ```bash
+     # local rewrite style helper if needed
+     npx @skillshub/cz-style-rewrite
+     ```
+7. Reconcile all writes with events:
+   ```bash
+   npx fourmeme events <fromBlock> [toBlock]
+   ```
+
+## Mandatory Safety Rules
+
+- Follow Four.meme current supported-chain constraints in runtime config.
+- Require explicit user confirmation for create, buy, sell, grant, and revoke.
+- Never accept plaintext private keys in conversation.
+- Keep operator scope minimal and revoke immediately after delegated actions.
+- Abort execution if quote exceeds risk caps (`maxSlippageBps`, `maxLossBnb`, `maxCapitalBnb`).
+
+## Source Anchors
+
+- four-meme-ai package and command set: https://www.npmjs.com/package/four-meme-ai
+- Four.meme protocol integration: https://four-meme.gitbook.io/four.meme/brand/protocol-integration
+- ERC-8004 draft specification: https://ercs.ethereum.org/ERCS/erc-8004

--- a/skills/four-meme-tax-token-guard/SKILL.md
+++ b/skills/four-meme-tax-token-guard/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: four_meme_tax_token_guard
+description: Plans TaxToken creation with fee-split sanity checks, anti-sniping defaults, explicit confirmation gates, and post-launch tax-info reconciliation.
+---
+
+# Four.Meme Tax Token Guard
+
+## Usage
+
+- Category: Ecosystem
+- Mode: guide
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "action": "create_tax_token",
+  "name": "Tax Agent Coin",
+  "symbol": "TAXA",
+  "taxFeeRate": 5,
+  "taxBurnRate": 0,
+  "taxDivideRate": 0,
+  "taxLiquidityRate": 100,
+  "taxRecipientRate": 0,
+  "budgetBnb": 0.01,
+  "dryRun": true
+}
+```
+
+## Workflow
+
+1. Run baseline checks:
+   ```bash
+   npx fourmeme verify
+   ```
+2. Build tax config and validate hard constraints before any write:
+   - all rates in allowed ranges.
+   - `burn + divide + liquidity + recipient = 100`.
+   - recipient address required when recipient rate > 0.
+3. Dry-run the command preview (recommended):
+   ```bash
+   npx fourmeme create-instant --image=... --name=... --short-name=... --desc=... --label=... --tax-token --tax-fee-rate=5 --tax-burn-rate=0 --tax-divide-rate=0 --tax-liquidity-rate=100 --tax-recipient-rate=0
+   ```
+   Or use `create-api` -> `create-chain` if the user wants two-step control.
+4. Ask explicit confirmation with final fee table and expected BNB spend.
+5. Execute create only after confirmation.
+6. Post-create reconciliation:
+   ```bash
+   npx fourmeme tax-info <tokenAddress>
+   npx fourmeme token-info <tokenAddress>
+   npx fourmeme events <fromBlock> [toBlock]
+   ```
+
+## Guardrails
+
+- Never accept plain-text private keys in chat.
+- Treat anti-sniping windows and tax defaults as risk controls, not guaranteed protection.
+- Refuse execution when fee splits are invalid or ambiguous.
+- Keep trading disabled in the same turn unless user separately confirms trade intent.
+
+## Source Anchors
+
+- Four.meme CLI TaxToken options: https://github.com/four-meme-community/four-meme-ai
+- Four.meme tax-token/X-Mode update: https://four-meme.gitbook.io/four.meme/blog/product-update-new-tax-token-model-with-x-mode-on-four.meme
+- Four.meme protocol integration + latest ABI/API notes: https://four-meme.gitbook.io/four.meme/brand/protocol-integration

--- a/skills/four-meme-trade-playbook/SKILL.md
+++ b/skills/four-meme-trade-playbook/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: four_meme_trade_playbook
+description: Creates quote-first Four.meme buy and sell execution plans with slippage, loss limits, and event-level reconciliation. Use when users ask to buy, sell, scale in, or scale out Four.meme tokens.
+---
+
+# Four.Meme Trade Playbook
+
+## Usage
+
+- Category: Ecosystem
+- Mode: guide
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "action": "buy",
+  "tokenAddress": "0x...",
+  "amountBnb": 0.25,
+  "maxSlippageBps": 150,
+  "maxLossBnb": 0.02,
+  "confirmation": "required"
+}
+```
+
+## Workflow
+
+1. Confirm token metadata and manager version:
+   ```bash
+   npx fourmeme token-info <tokenAddress>
+   ```
+2. Generate quote before execution:
+   ```bash
+   npx fourmeme quote-buy <tokenAddress> <amountOrFunds>
+   npx fourmeme quote-sell <tokenAddress> <amountWei>
+   ```
+3. Validate quote against policy:
+   - `slippageBps <= maxSlippageBps`
+   - `expectedLoss <= maxLossBnb`
+   - liquidity and tax flags reviewed
+4. Ask for explicit order confirmation (`CONFIRM_BUY` or `CONFIRM_SELL`).
+5. Execute trade after confirmation:
+   ```bash
+   npx fourmeme buy <tokenAddress> <amountOrFunds> ...
+   npx fourmeme sell <tokenAddress> <amountWei> [minFundsWei]
+   ```
+6. Reconcile with recent events:
+   ```bash
+   npx fourmeme events <fromBlock> [toBlock]
+   ```
+
+## Guardrails
+
+- Enforce quote-first; never jump directly to `buy` or `sell`.
+- If TokenManager version is unsupported, stop and report.
+- Require human confirmation for any non-read operation.
+- Prefer partial-size execution when volatility is high.
+
+## Source Anchors
+
+- four-meme-ai package + command surface: https://www.npmjs.com/package/four-meme-ai
+- Four.meme protocol integration page: https://four-meme.gitbook.io/four.meme/brand/protocol-integration

--- a/skills/funding-basis-carry-scan/SKILL.md
+++ b/skills/funding-basis-carry-scan/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: funding_basis_carry_scan
+description: Combines funding history and basis term structure to surface carry setups with risk labels.
+---
+
+# Funding Basis Carry Scan
+
+## Usage
+
+- Category: Derivatives
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "symbol": "BTCUSDT",
+  "pair": "BTCUSDT",
+  "contractType": "PERPETUAL",
+  "period": "1h",
+  "limit": 12
+}
+```
+
+## Local Install (planned)
+
+```bash
+npx @skillshub/funding-basis-carry-scan
+```
+
+## Notes
+
+- Produces carry-oriented setup suggestion only; does not execute orders.
+- Always combine with position sizing and liquidation risk checks.

--- a/skills/funding-watch/SKILL.md
+++ b/skills/funding-watch/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: funding_watch
+description: Reads funding rate, annualized estimate, and mark-index basis from Binance Futures.
+---
+
+# Funding Watch
+
+## Usage
+
+- Category: Derivatives
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+{
+  "symbol": "BTCUSDT"
+}
+
+## Local Install (planned)
+
+npx @skillshub/funding-watch

--- a/skills/kline-brief/SKILL.md
+++ b/skills/kline-brief/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: kline_brief
+description: Summarizes recent candles with trend percentage.
+---
+
+# Kline Brief
+
+## Usage
+
+- Category: Charts
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+{
+  "symbol": "BNBUSDT",
+  "interval": "15m",
+  "limit": 24
+}
+
+## Local Install (planned)
+
+npx @skillshub/kline-brief

--- a/skills/liquidation-heatmap/SKILL.md
+++ b/skills/liquidation-heatmap/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: liquidation_heatmap
+description: Aggregates recent force orders to estimate long-vs-short liquidation pressure.
+---
+
+# Liquidation Heatmap
+
+## Usage
+
+- Category: Derivatives
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "symbol": "BTCUSDT",
+  "windowMinutes": 60,
+  "limit": 50
+}
+```
+
+## Local Install (planned)
+
+```bash
+npx @skillshub/liquidation-heatmap
+```
+
+## Notes
+
+- Uses recent force-order data to approximate liquidation imbalance.
+- Best used with trend and funding context to avoid one-signal bias.

--- a/skills/open-interest-scan/SKILL.md
+++ b/skills/open-interest-scan/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: open_interest_scan
+description: Tracks futures open interest and taker flow changes for a symbol.
+---
+
+# Open Interest Scan
+
+## Usage
+
+- Category: Derivatives
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+```json
+{
+  "symbol": "ETHUSDT",
+  "period": "5m",
+  "limit": 2
+}
+```
+
+## Local Install (planned)
+
+```bash
+npx @skillshub/open-interest-scan
+```

--- a/skills/price-snapshot/SKILL.md
+++ b/skills/price-snapshot/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: price_snapshot
+description: Fetches spot last price and 24h change for one trading pair.
+---
+
+# Price Snapshot
+
+## Usage
+
+- Category: Market Data
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+{
+  "symbol": "BTCUSDT"
+}
+
+## Local Install (planned)
+
+npx @skillshub/price-snapshot

--- a/skills/symbol-status/SKILL.md
+++ b/skills/symbol-status/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: symbol_status
+description: Checks trading status and filters from exchangeInfo.
+---
+
+# Symbol Status Checker
+
+## Usage
+
+- Category: Operations
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+{
+  "symbol": "SOLUSDT"
+}
+
+## Local Install (planned)
+
+npx @skillshub/symbol-status

--- a/skills/top-movers/SKILL.md
+++ b/skills/top-movers/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: top_movers
+description: Ranks top symbols by 24h change or quote volume with optional liquidity filter.
+---
+
+# Top Movers Radar
+
+## Usage
+
+- Category: Analytics
+- Mode: live
+- Version: 0.1.0
+
+## Input Example
+
+{
+  "quoteAsset": "USDT",
+  "limit": 8,
+  "minQuoteVolume": 50000000,
+  "sortBy": "change"
+}
+
+## Local Install (planned)
+
+npx @skillshub/top-movers-radar


### PR DESCRIPTION
## Summary

  This PR adds an original SkillHub pack to `bnbchain-skills`, combining:
  1) market analysis workflows (read-first), and
  2) Four.meme operational workflows with our own authored process design.

  All content is additive (`SKILL.md` + README registration), focused on
  practical agent usage.

  ## Included Skills

  ### Market Pack (11)
  - bsc-honeypot-check
  - bsc-rpc-fanout-check
  - crowding-risk-scan
  - funding-basis-carry-scan
  - funding-watch
  - kline-brief
  - liquidation-heatmap
  - open-interest-scan
  - price-snapshot
  - symbol-status
  - top-movers

  ### Four.meme Workflow Pack (7, original tracked)
  - four-meme-agentic-ops
  - four-meme-create-pipeline
  - four-meme-graduation-radar
  - four-meme-mempool-sentinel
  - four-meme-one-stop-bsc
  - four-meme-tax-token-guard
  - four-meme-trade-playbook

  ## Selection Policy

  - Included Four.meme skills are from our tracked git history with
  iterative modifications.
  - Excluded official-bridge style and no-history items in this batch to
  keep provenance clear and review-friendly.

  ## Notes

  - No secrets, binaries, or unrelated code changes.
  - No modification to existing `bnbchain-mcp-skill` behavior.
  - Follow-up PR can add additional ecosystem skills after maintainer
  feedback.