### PR TITLE
Remove ghost tools that do not exist in MCP server

### DIFF
--- a/skills/bnbchain-mcp-skill/SKILL.md
+++ b/skills/bnbchain-mcp-skill/SKILL.md
@@ -72,12 +72,12 @@ Restart or reload the MCP client after changing config so the server starts.
 | Category | Examples | Needs PRIVATE_KEY? |
 |----------|----------|--------------------|
 | Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
-| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Transactions | `get_transaction`, `estimate_gas` | No |
 | Network | `get_chain_info`, `get_supported_networks` | No |
 | Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
 | Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
 | Contracts | `read_contract`, `is_contract` | No for read |
-| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata` | No for read |
 | ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
 | Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
 

--- a/skills/bnbchain-mcp-skill/references/evm-tools-reference.md
+++ b/skills/bnbchain-mcp-skill/references/evm-tools-reference.md
@@ -24,7 +24,6 @@ Tools that require **PRIVATE_KEY** in the MCP server env are marked with **(writ
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | get_transaction | Get transaction by hash | `txHash`, `network` |
-| get_transaction_receipt | Get receipt by hash | `txHash`, `network` |
 | estimate_gas | Estimate gas for a tx | `to`, `value` (optional, e.g. "0.1"), `data` (optional hex), `network` |
 
 ---
@@ -84,18 +83,6 @@ Tools that require **PRIVATE_KEY** in the MCP server env are marked with **(writ
 |------|-------------|------------|
 | get_nft_info | ERC721 metadata, owner | `tokenAddress`, `tokenId`, `network` |
 | get_erc1155_token_metadata | ERC1155 token metadata | `tokenAddress`, `tokenId`, `network` |
-| check_nft_ownership | Whether address owns NFT | (Check with get_nft_info or contract read if available) |
-| get_nft_balance | NFT count for address in collection | (Use read_contract with balanceOf if needed) |
-| get_erc1155_balance | Balance of ERC1155 token ID for address | (Use read_contract with balanceOf if needed) |
 
 Transfer tools: see **Wallet and balances** above (`transfer_nft`, `transfer_erc1155`).
 
----
-
-## ENS
-
-| Tool | Description | Parameters |
-|------|-------------|------------|
-| resolve_ens | Resolve ENS name to address | `ensName`, `network` (typically ethereum) |
-
-Note: ENS is not supported on BSC; use on Ethereum or other chains where ENS is deployed.


### PR DESCRIPTION
## Summary
- Removed 7 tools documented but not registered in bnbchain-mcp server
- check_nft_ownership, get_nft_balance, get_erc1155_balance: not in src/evm/modules/nft/tools.ts
- resolve_ens: commented out in src/evm/modules/network/tools.ts
- get_transaction_receipt: not in src/evm/modules/transactions/tools.ts
- Agents calling these tools will get tool-not-found errors

## Type of Change
- [x] Bug fix

## Testing
- [x] Cross-referenced against bnbchain-mcp source code