### PR TITLE
Fix incorrect Greenfield tool names

### DIFF
--- a/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
+++ b/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
@@ -26,12 +26,12 @@ Greenfield tools operate on **testnet** or **mainnet**. Use **`network`**: `"tes
 |------|-------------|------------|
 | gnfd_list_objects | List objects in a bucket | `network`, `bucketName` |
 | gnfd_get_object_info | Object details | `network`, `bucketName`, `objectName` |
-| gnfd_upload_object / gnfd_create_file | **(Write)** Upload a file to a bucket | `network`, `privateKey`, `filePath` (absolute path to file), `bucketName` |
+| gnfd_create_file | **(Write)** Upload a file to a bucket | `network`, `privateKey`, `filePath` (absolute path to file), `bucketName` |
 | gnfd_download_object | Download object to disk | `network`, `bucketName`, `objectName`, `targetPath` (optional), `privateKey` |
 | gnfd_delete_object | **(Write)** Delete an object | `network`, `privateKey`, `bucketName`, `objectName` |
 | gnfd_create_folder | **(Write)** Create a folder in a bucket | `network`, `privateKey`, `bucketName`, `folderName` (optional) |
 
-If the server exposes **gnfd_create_file** instead of **gnfd_upload_object**, use **filePath** (absolute path to the file to upload).
+The registered tool name is **gnfd_create_file**. Use **filePath** (absolute path to the file to upload).
 
 ---
 
@@ -42,7 +42,7 @@ If the server exposes **gnfd_create_file** instead of **gnfd_upload_object**, us
 | gnfd_get_account_balance | Balance for a Greenfield account | `network`, address/privateKey as per implementation |
 | gnfd_get_payment_accounts | Payment accounts for an address | `network`, `address` (optional), `privateKey` |
 | gnfd_get_payment_account_info | Details of a payment account | `network`, account identifier (see implementation) |
-| gnfd_create_payment | **(Write)** Create a payment account | `network`, `privateKey` |
+| gnfd_create_payment_account | **(Write)** Create a payment account | `network`, `privateKey` |
 | gnfd_get_payment_balance | Payment account balance | `network`, account identifier |
 | gnfd_deposit_to_payment | **(Write)** Deposit into payment account | `network`, `to` (payment account address), `amount` (string, in BNB), `privateKey` |
 | gnfd_withdraw_from_payment | **(Write)** Withdraw from payment account | `network`, `from`, `amount`, `privateKey` |


### PR DESCRIPTION
gnfd_upload_object is not a registered tool name (only gnfd_create_file exists). gnfd_create_payment should be gnfd_create_payment_account. Using wrong names causes tool-not-found errors.