### PR TITLE
Add missing privateKey parameters to Greenfield tool documentation

### DIFF
--- a/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
+++ b/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
@@ -10,9 +10,9 @@ Greenfield tools operate on **testnet** or **mainnet**. Use **`network`**: `"tes
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| gnfd_list_buckets | List buckets owned by an address | `network`, `address` (optional), `privateKey` (optional for default account) |
+| gnfd_list_buckets | List buckets owned by an address | `network`, `address` (optional), `privateKey` (required, defaults to env PRIVATE_KEY) |
 | gnfd_get_bucket_info | Bucket details | `network`, `bucketName` |
-| gnfd_get_bucket_full_info | Bucket info and quota usage | `network`, `bucketName`, `privateKey` |
+| gnfd_get_bucket_full_info | Bucket info and quota usage | `network`, `bucketName`, `privateKey` (required, defaults to env PRIVATE_KEY) |
 | gnfd_create_bucket | **(Write)** Create a bucket | `network`, `privateKey`, `bucketName` |
 | gnfd_delete_bucket | **(Write)** Delete a bucket | `network`, `privateKey`, `bucketName` |
 
@@ -27,7 +27,7 @@ Greenfield tools operate on **testnet** or **mainnet**. Use **`network`**: `"tes
 | gnfd_list_objects | List objects in a bucket | `network`, `bucketName` |
 | gnfd_get_object_info | Object details | `network`, `bucketName`, `objectName` |
 | gnfd_upload_object / gnfd_create_file | **(Write)** Upload a file to a bucket | `network`, `privateKey`, `filePath` (absolute path to file), `bucketName` |
-| gnfd_download_object | Download object to disk | `network`, `bucketName`, `objectName`, `targetPath` (optional), `privateKey` |
+| gnfd_download_object | Download object to disk | `network`, `bucketName`, `objectName`, `targetPath` (optional), `privateKey` (required, defaults to env PRIVATE_KEY) |
 | gnfd_delete_object | **(Write)** Delete an object | `network`, `privateKey`, `bucketName`, `objectName` |
 | gnfd_create_folder | **(Write)** Create a folder in a bucket | `network`, `privateKey`, `bucketName`, `folderName` (optional) |
 


### PR DESCRIPTION
Several Greenfield tools were missing the required privateKey parameter. In the MCP source, privateKey is a required parameter that defaults to env PRIVATE_KEY. Without documenting it, agents won't include it in tool calls.