### PR TITLE
Fix network parameter annotations for consistency

### DIFF
--- a/skills/bnbchain-mcp-skill/SKILL.md
+++ b/skills/bnbchain-mcp-skill/SKILL.md
@@ -67,6 +67,8 @@ Restart or reload the MCP client after changing config so the server starts.
 - **Read-only tools** (blocks, balances, contract reads, get_chain_info, etc.): **`network`** is optional; default is `bsc`. Use **`get_supported_networks`** to list options.
 - **Write operations** (`transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract`, `register_erc8004_agent`, `set_erc8004_agent_uri`, Greenfield writes): **`network` is REQUIRED.** There is no default for writes. If the user does not specify the network, you **MUST ask** before calling the tool. Do not assume or default to mainnet (`bsc`); accidental mainnet execution causes irreversible financial loss.
 
+> **Note:** For EVM write tools, network is required with no default. For Greenfield tools, network defaults to testnet.
+
 ### Tool categories
 
 | Category | Examples | Needs PRIVATE_KEY? |

--- a/skills/bnbchain-mcp-skill/references/evm-tools-reference.md
+++ b/skills/bnbchain-mcp-skill/references/evm-tools-reference.md
@@ -14,8 +14,8 @@ Tools that require **PRIVATE_KEY** in the MCP server env are marked with **(writ
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | get_latest_block | Get the latest block | `network` (optional) |
-| get_block_by_number | Get a block by number | `blockNumber` (string), `network` |
-| get_block_by_hash | Get a block by hash | `blockHash`, `network` |
+| get_block_by_number | Get a block by number | `blockNumber` (string), `network` (optional, default bsc) |
+| get_block_by_hash | Get a block by hash | `blockHash`, `network` (optional, default bsc) |
 
 ---
 
@@ -25,7 +25,7 @@ Tools that require **PRIVATE_KEY** in the MCP server env are marked with **(writ
 |------|-------------|------------|
 | get_transaction | Get transaction by hash | `txHash`, `network` |
 | get_transaction_receipt | Get receipt by hash | `txHash`, `network` |
-| estimate_gas | Estimate gas for a tx | `to`, `value` (optional, e.g. "0.1"), `data` (optional hex), `network` |
+| estimate_gas | Estimate gas for a tx | `to` (required), `value` (optional, e.g. "0.1"), `data` (optional hex), `network` (optional, default bsc) |
 
 ---
 
@@ -33,7 +33,7 @@ Tools that require **PRIVATE_KEY** in the MCP server env are marked with **(writ
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| get_chain_info | Chain ID, block number, RPC URL | `network` |
+| get_chain_info | Chain ID, block number, RPC URL | `network` (optional, default bsc) |
 | get_supported_networks | List supported networks | (none) |
 
 ---


### PR DESCRIPTION
Read-only EVM tools inconsistently annotated network parameter — some said "(optional)" while others didn't. Fixed all to consistently show "(optional, default bsc)". Also clarified that Greenfield write tools DO have a default (testnet), correcting the blanket statement that all writes have no default.