### PR TITLE
Replace vague parameter descriptions with actual parameter names in G…

### DIFF
--- a/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
+++ b/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
@@ -29,7 +29,7 @@ Greenfield tools operate on **testnet** or **mainnet**. Use **`network`**: `"tes
 | gnfd_upload_object / gnfd_create_file | **(Write)** Upload a file to a bucket | `network`, `privateKey`, `filePath` (absolute path to file), `bucketName` |
 | gnfd_download_object | Download object to disk | `network`, `bucketName`, `objectName`, `targetPath` (optional), `privateKey` |
 | gnfd_delete_object | **(Write)** Delete an object | `network`, `privateKey`, `bucketName`, `objectName` |
-| gnfd_create_folder | **(Write)** Create a folder in a bucket | `network`, `privateKey`, `bucketName`, `folderName` (optional) |
+| gnfd_create_folder | **(Write)** Create a folder in a bucket | `network`, `privateKey`, `bucketName`, `folderName` (optional, default: `created-by-bnbchain-mcp`) |
 
 If the server exposes **gnfd_create_file** instead of **gnfd_upload_object**, use **filePath** (absolute path to the file to upload).
 
@@ -39,9 +39,9 @@ If the server exposes **gnfd_create_file** instead of **gnfd_upload_object**, us
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| gnfd_get_account_balance | Balance for a Greenfield account | `network`, address/privateKey as per implementation |
+| gnfd_get_account_balance | Balance for a Greenfield account | `network`, `address` (optional), `privateKey` (required, defaults to env PRIVATE_KEY) |
 | gnfd_get_payment_accounts | Payment accounts for an address | `network`, `address` (optional), `privateKey` |
-| gnfd_get_payment_account_info | Details of a payment account | `network`, account identifier (see implementation) |
+| gnfd_get_payment_account_info | Details of a payment account | `network`, `paymentAddress` (required) |
 | gnfd_create_payment | **(Write)** Create a payment account | `network`, `privateKey` |
 | gnfd_get_payment_balance | Payment account balance | `network`, account identifier |
 | gnfd_deposit_to_payment | **(Write)** Deposit into payment account | `network`, `to` (payment account address), `amount` (string, in BNB), `privateKey` |


### PR DESCRIPTION
…reenfield reference

## Summary
- Replaced "address/privateKey as per implementation" with actual parameter names and required/optional annotations
- Replaced "account identifier (see implementation)" with `paymentAddress (required)`
- Added default value for `folderName` parameter

## Type of Change
- [x] Documentation fix

## Changes Made
- gnfd_get_account_balance: vague params → `address (optional), privateKey (required, defaults to env PRIVATE_KEY)`
- gnfd_get_payment_account_info: "see implementation" → `paymentAddress (required)`
- gnfd_create_folder: added default value documentation

## Testing
- [x] Cross-referenced against bnbchain-mcp source code