### PR TITLE
Add missing create_erc20_token tool documentation

### DIFF
--- a/skills/bnbchain-mcp-skill/references/evm-tools-reference.md
+++ b/skills/bnbchain-mcp-skill/references/evm-tools-reference.md
@@ -75,6 +75,7 @@ Tools that require **PRIVATE_KEY** in the MCP server env are marked with **(writ
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | get_erc20_token_info | Name, symbol, decimals | `tokenAddress`, `network` |
+| create_erc20_token | Deploy a new ERC20 token contract | `name` (required), `symbol` (required), `network` (required), `privateKey` (required, or env PRIVATE_KEY) | **(Write)** |
 
 ---
 


### PR DESCRIPTION
## Summary
- Documented `create_erc20_token` tool that exists in bnbchain-mcp but was not in the skills reference

## Type of Change
- [x] Documentation improvement

## Changes Made
- Added create_erc20_token row to Tokens (ERC20) section with parameters: name, symbol, network, privateKey

## Testing
- [x] Verified tool exists in bnbchain-mcp source (src/evm/modules/tokens/tools.ts)