### PR TITLE
Add missing gnfd_get_all_sps tool documentation

### DIFF
--- a/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
+++ b/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
@@ -35,7 +35,13 @@ If the server exposes **gnfd_create_file** instead of **gnfd_upload_object**, us
 
 ---
 
-## Account and payment
+## Account and info
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| gnfd_get_all_sps | List all Greenfield storage providers | `network` |
+
+## Payment
 
 | Tool | Description | Parameters |
 |------|-------------|------------|


### PR DESCRIPTION
## Summary
- Documented `gnfd_get_all_sps` tool (list all Greenfield storage providers) that exists in MCP but was undocumented

## Type of Change
- [x] Documentation improvement

## Changes Made
- Added gnfd_get_all_sps to Greenfield tools reference

## Testing
- [x] Verified tool exists in bnbchain-mcp source (src/gnfd/tools/account.ts)