### PR TITLE
Add Greenfield chain IDs and RPC endpoint documentation

### DIFF
--- a/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
+++ b/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md
@@ -2,6 +2,13 @@
 
 Greenfield tools operate on **testnet** or **mainnet**. Use **`network`**: `"testnet"` (default) or `"mainnet"`. Writes require **PRIVATE_KEY** in the MCP server env (or passed where supported).
 
+## Network Configuration
+
+| Network | Chain ID | RPC Endpoint |
+|---------|----------|--------------|
+| Greenfield Mainnet | 1017 | https://greenfield-chain.bnbchain.org |
+| Greenfield Testnet | 5600 | https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org |
+
 **Note:** Some tools may be named differently in the implementation (e.g. file upload). Use the tool names exposed by the MCP server; below matches the [BNB Chain MCP README](https://github.com/bnb-chain/bnbchain-mcp) and common usage.
 
 ---


### PR DESCRIPTION
## Summary
- Added Network Configuration table with chain IDs and RPC endpoints for Greenfield mainnet and testnet

## Type of Change
- [x] Documentation improvement

## Changes Made
- Greenfield Mainnet: Chain ID 1017, RPC endpoint
- Greenfield Testnet: Chain ID 5600, RPC endpoint