### PR TITLE
Fix estimate_gas parameter annotations

### DIFF
--- a/skills/bnbchain-mcp-skill/references/evm-tools-reference.md
+++ b/skills/bnbchain-mcp-skill/references/evm-tools-reference.md
@@ -25,7 +25,7 @@ Tools that require **PRIVATE_KEY** in the MCP server env are marked with **(writ
 |------|-------------|------------|
 | get_transaction | Get transaction by hash | `txHash`, `network` |
 | get_transaction_receipt | Get receipt by hash | `txHash`, `network` |
-| estimate_gas | Estimate gas for a tx | `to`, `value` (optional, e.g. "0.1"), `data` (optional hex), `network` |
+| estimate_gas | Estimate gas for a tx | `to` (required), `value` (optional, e.g. "0.1"), `data` (optional, hex-encoded), `network` (optional, default `bsc`) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Made required/optional annotations explicit for estimate_gas parameters

## Type of Change
- [x] Documentation fix

## Changes Made
- `to` marked as (required)
- `network` marked as (optional, default bsc)
- `value` and `data` annotations clarified