### PR TITLE
Fix displayName to use human-readable label

### DIFF
--- a/skills/bnbchain-mcp-skill/SKILL.md
+++ b/skills/bnbchain-mcp-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bnbchain-mcp
-displayName: bnbchain-mcp
+displayName: BNB Chain MCP
 version: 1.0.0
 description: BNB Chain MCP server connection and tool usage. Covers npx @bnb-chain/mcp@latest, PRIVATE_KEY and RPC, and every MCP tool — blocks, transactions, contracts, ERC20/NFT transfers, wallet, ERC-8004 agent registration, Greenfield. Use when connecting to bnbchain-mcp, querying or transacting on BNB Chain/opBNB/EVM, registering as ERC-8004 agent, or using Greenfield.
 ---


### PR DESCRIPTION
## Summary
- Changed displayName from redundant "bnbchain-mcp" to human-readable "BNB Chain MCP"

## Type of Change
- [x] Documentation fix

## Changes Made
- displayName: bnbchain-mcp → BNB Chain MCP